### PR TITLE
Refreshing the ConsumptionState context on login.

### DIFF
--- a/Water Drink Water/src/clients/blazor.wa.tbd/Components/Login.razor.cs
+++ b/Water Drink Water/src/clients/blazor.wa.tbd/Components/Login.razor.cs
@@ -1,13 +1,12 @@
-﻿using blazor.wa.tbd.Infrastructure;
-using blazor.wa.tbd.Services;
+﻿using blazor.wa.tbd.Services;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Authorization;
 
 namespace blazor.wa.tbd.Components;
 
 public partial class Login
 {
     private readonly LoginFormData formData = new();
+    [CascadingParameter] private ConsumptionStateProvider ConsumptionState { get; set; }
     [Inject] public UserService UserService { get; set; }
     [Inject] public NavigationManager NavigationManager { get; set; }
     [Inject] public AuthService AuthService { get; set; }
@@ -28,6 +27,7 @@ public partial class Login
         }
         else
         {
+            await ConsumptionState.RefreshContext();
             NavigationManager.NavigateTo("/log");
         }
     }


### PR DESCRIPTION
When we log in, we never initially get the value to the water consumption gauge. By refreshing it upon login. We can see the updated gauge. Doing it in this place, I keep in mind if we ever decide to switch where we go after log in. It will still work.